### PR TITLE
add scope to single model journey

### DIFF
--- a/lib/form_journey/uses_single_model.rb
+++ b/lib/form_journey/uses_single_model.rb
@@ -42,8 +42,10 @@ module FormJourney
       if scope.respond_to?(:call)
         instance_exec(model_class, &scope)
       else
-        message, *params = Array(scope)
-        model_class.send(message.to_sym, *params)
+        messages = Array(scope)
+        messages.reduce(model_class) do |chained_scope, message|
+          chained_scope.send(message.to_sym)
+        end
       end
     end
 

--- a/spec/lib/form_journey/uses_single_model_spec.rb
+++ b/spec/lib/form_journey/uses_single_model_spec.rb
@@ -172,31 +172,21 @@ RSpec.describe FormJourney::Controller do
         end
       end
 
-      context 'using a message' do
-        context 'with params' do
-          let(:scope) { nil }
-          let(:message) { :some_scope }
-          let(:scope_params) { [:a, :b, :c] }
+      context 'using chained messages' do
+        let(:scope) { nil }
+        let(:message) { :some_scope }
+        let(:message2) { :some_other_scope }
 
-          before do
-            subject.class.model_scope message, *scope_params
-          end
-
-          it 'should attempt to call it with params' do
-            expect(DummyModel).to receive(message).with(*scope_params)
-              .and_return(DummyModel)
-            subject.dummy_model
-          end
+        before do
+          subject.class.model_scope message, message2
         end
 
-        context 'with no params' do
-          let(:scope) { :some_scope }
-
-          it 'should attempt to call it' do
-            expect(DummyModel).to receive(scope).and_return(DummyModel)
-            subject.dummy_model
-          end
+        it 'should attempt to call all messages' do
+          expect(DummyModel).to receive(message).and_return(DummyModel)
+          expect(DummyModel).to receive(message2).and_return(DummyModel)
+          subject.dummy_model
         end
+
       end
     end
 


### PR DESCRIPTION
The key to getting the context working was instance_exec to allow me to pass the class as an argument
