### PR TITLE
Fix to params with string keys

### DIFF
--- a/lib/form_journey/parameters.rb
+++ b/lib/form_journey/parameters.rb
@@ -2,7 +2,7 @@ module FormJourney
   class Parameters < HashWithIndifferentAccess
     def initialize(attributes = nil, session)
       @session = (session || {})
-      @session.deep_merge!(attributes) if attributes
+      @session.deep_merge!(attributes.deep_symbolize_keys) if attributes
       super(@session)
     end
 

--- a/spec/lib/form_journey/parameters_spec.rb
+++ b/spec/lib/form_journey/parameters_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe FormJourney::Parameters do
     }
   end
 
-  let(:request_session) do
-    @request_session = {
+  let!(:request_session) do
+    {
       user: {
         email: 'email@example.com'
       }
@@ -145,6 +145,24 @@ RSpec.describe FormJourney::Parameters do
           address: 'Regent Street'
         }
       })
+    end
+
+    context 'with empty session' do
+      before do
+        params.clear
+        request_session.clear
+      end
+
+      it 'updates deep values' do
+        subject.set(:user, value: { address: 'Regent Street' })
+        new_subject = FormJourney::Parameters.new({ 'user' => { 'name' => 'Test' } }, request_session)
+        expect(request_session).to eq({
+          user: {
+            address: 'Regent Street',
+            name: 'Test'
+          }
+        })
+      end
     end
   end
 


### PR DESCRIPTION
If we had a session setted and we tried to update a nested hash using params with string keys, we would end up with a duplicate value on the session